### PR TITLE
Fixed false negatives on linux script

### DIFF
--- a/LINUX/LinuxRequirements.md
+++ b/LINUX/LinuxRequirements.md
@@ -1,21 +1,39 @@
-#sudo apt-get install lsb-release
-#On Red Hat-based systems, you can use yum or dnf:
-#sudo yum install redhat-lsb-core  # for CentOS, RHEL
-#sudo dnf install redhat-lsb-core  # for Fedora
 
-echo "Checking lsb-release"
-dpkg -s lsb-release | grep -i status
-echo "Checking jq"
-dpkg -s jq | grep -i status
-echo "Checking curl"
-dpkg -s curl | grep -i status
-echo "Checking sed"
-dpkg -s sed | grep -i status
-echo "Checking netcat - To run NC"
-dpkg -s netcat | grep -i status
+# Install dependencies
+``` bash
+sudo apt-get update
+sudo apt-get -y install lsb-release jq curl sed netcat-traditional
+```
+On Red Hat-based systems, you can use yum or dnf, as in the examples below
+``` bash
+sudo yum install redhat-lsb-core  # for CentOS, RHEL
+```
+``` bash
+sudo dnf install redhat-lsb-core  # for Fedora
+```
 
-#to run
+### Check if dependencies are installed
+``` bash
+echo "Checking lsb-release" | dpkg -s lsb-release | grep -i status
+echo "Checking jq" | dpkg -s jq | grep -i status
+echo "Checking curl" | dpkg -s curl | grep -i status
+echo "Checking sed" | dpkg -s sed | grep -i status
+echo "Checking netcat - To run NC" | dpkg -s netcat | grep -i status
+echo "Checking netcat-traditional - To run NC" | dpkg -s netcat | grep -i status
+```
+
+### get script
+``` bash
+wget https://raw.githubusercontent.com/microsoft/Azure-Synapse-Connectivity-Checker/main/LINUX/Synapse-TestConnection-linux.sh
+```
+
+### make executable
+``` bash
 chmod +x Synapse-TestConnection-linux.sh
+```
 
+### run
+``` bash
 ./Synapse-TestConnection-linux.sh
+```
 

--- a/LINUX/Synapse-TestConnection-linux.sh
+++ b/LINUX/Synapse-TestConnection-linux.sh
@@ -209,7 +209,7 @@ print_port_status() {
     tcpClient=$(nc -v -z -w "$timeout" "$endpoint" "$port" 2>&1)
 
     # Check if the port is open
-    if [[ "$tcpClient" == *succeeded* ]] || [[ "$tcpClient" == *Connected* ]]; then
+    if [[ "$tcpClient" == *succeeded* ]] || [[ "$tcpClient" == *Connected* ]] || [[ "$tcpClient" == *open* ]]; then
         echo -e "${Green} > Port $port on $endpoint is open${Color_Off}"
     else
         echo -e "${Red} > Port $port on $endpoint is closed${Color_Off}"


### PR DESCRIPTION
Added 'open' as an accepted result for the netcat command. 
Also formatted some Markdown on the LinuxRequirements.md
![netcat_result](https://github.com/microsoft/Azure-Synapse-Connectivity-Checker/assets/671608/d92f2743-b92d-4221-8fbb-ce30a62f1d31)
 file.